### PR TITLE
fix: Error bad centralized. Issues  Fixed #23

### DIFF
--- a/src/wc-toast-icon.js
+++ b/src/wc-toast-icon.js
@@ -153,7 +153,6 @@ export default class WCToastIcon extends HTMLElement {
 
       .error-icon svg{
         width: 16px;
-        padding-left: 1px;
         height: 20px;
         stroke: #fff;
         animation: slide-in .2s ease-out;


### PR DESCRIPTION
Before
![before](https://github.com/abdmmar/wc-toast/assets/88260564/1029529e-6576-4806-bfc3-11c92ef6ee9d)
After
![after](https://github.com/abdmmar/wc-toast/assets/88260564/73abaae2-3961-4ec1-952d-c094f084d9ea)

css correction and remove padding
 .error-icon svg{
        padding-left: 1px;
